### PR TITLE
1.1.0-0: Allow the user to modify the priority of the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ KONG_LUA_SSL_VERIFY_DEPTH=2
 
 For more information please refer to https://discuss.konghq.com/t/kong-log-error-about-certificate/6371/6
 
+## Priority
+By default, the priority of the plugin is 900. You can change it using an environment variable:
+```
+EXTERNAL_OAUTH_REQUEST_PRIORITY=1000
+```
+
 ## Author
 
 Optare Solutions

--- a/kong-plugin-external-oauth-request-1.1.0-0.rockspec
+++ b/kong-plugin-external-oauth-request-1.1.0-0.rockspec
@@ -1,6 +1,6 @@
 local plugin_name = "external-oauth-request"
 local package_name = "kong-plugin-" .. plugin_name
-local package_version = "1.0.0"
+local package_version = "1.1.0"
 local rockspec_revision = "0"
 
 local github_account_name = "OptareSolutions"

--- a/kong/plugins/external-oauth-request/handler.lua
+++ b/kong/plugins/external-oauth-request/handler.lua
@@ -7,10 +7,21 @@ local ExternalAuthHandler = BasePlugin:extend()
 local CACHE_TOKEN_KEY = "oauth_token"
 local EXPIRATION_MARGIN = 5
 
+local priority_env_var = "EXTERNAL_OAUTH_REQUEST_PRIORITY"
+local priority
+if os.getenv(priority_env_var) then
+    priority = tonumber(os.getenv(priority_env_var))
+else
+    priority = 900
+end
+kong.log.debug('EXTERNAL_OAUTH_REQUEST_PRIORITY: ' .. priority)
+
+ExternalAuthHandler.PRIORITY = priority
+ExternalAuthHandler.VERSION = "1.1.0"
+
 function ExternalAuthHandler:new()
   ExternalAuthHandler.super.new(self, "external-oauth-request")
 end
-
 
 -----------
 -- ACCESS


### PR DESCRIPTION
Add envvar EXTERNAL_OAUTH_REQUEST_PRIORITY so the user can modify the priority of the plugin

Also, modify the version of the plugin and the .rockspec filename to 1.1.0-0