### PR TITLE
Fix priority & version overriding

### DIFF
--- a/kong-plugin-external-oauth-request-1.1.1-0.rockspec
+++ b/kong-plugin-external-oauth-request-1.1.1-0.rockspec
@@ -1,6 +1,6 @@
 local plugin_name = "external-oauth-request"
 local package_name = "kong-plugin-" .. plugin_name
-local package_version = "1.1.0"
+local package_version = "1.1.1"
 local rockspec_revision = "0"
 
 local github_account_name = "OptareSolutions"

--- a/kong/plugins/external-oauth-request/handler.lua
+++ b/kong/plugins/external-oauth-request/handler.lua
@@ -17,7 +17,7 @@ end
 kong.log.debug('EXTERNAL_OAUTH_REQUEST_PRIORITY: ' .. priority)
 
 ExternalAuthHandler.PRIORITY = priority
-ExternalAuthHandler.VERSION = "1.1.0"
+ExternalAuthHandler.VERSION = "1.1.1"
 
 function ExternalAuthHandler:new()
   ExternalAuthHandler.super.new(self, "external-oauth-request")
@@ -184,8 +184,5 @@ function get_token_from_response(res, conf)
     expiration = expiration
   };
 end
-
-ExternalAuthHandler.PRIORITY = 900
-ExternalAuthHandler.VERSION = "1.0.0"
 
 return ExternalAuthHandler


### PR DESCRIPTION
This PR fixes a bug where the priority of the plugin gets overwritten by a default value (900) instead of honoring the ENV EXTERNAL_OAUTH_REQUEST_PRIORITY.

Also, fixes the same problem with the plugin version